### PR TITLE
Node HTTP: Handling Request Body Conversion

### DIFF
--- a/packages/node-http/src/index.ts
+++ b/packages/node-http/src/index.ts
@@ -32,8 +32,18 @@ function getRequestBody(req: IncomingMessageWithBody): Promise<string> {
       // add `body` to request for downstream readers
       req.body = Buffer.concat(buffer);
 
-      // resolve promise
-      resolve(req.body.toString());
+      // Convert Buffer to a string
+      const contentType = req.headers['content-type'] || '';
+
+      if (contentType.includes('application/json')) {
+          req.body = JSON.parse(req.body.toString());
+      } else if (contentType.includes('application/x-www-form-urlencoded')) {
+          req.body = req.body.toString(); // Keep it as a string for form submissions
+      } else {
+          req.body = req.body.toString(); // Default to string conversion
+      }
+
+      resolve(req.body); // Resolve with the properly formatted body
     };
 
     const onErr = (err: Error) => {


### PR DESCRIPTION
Hi,
I'm using @edge-csrf/node-http in my project which has a form that sends data from Next.js ( using custom Node server ) to Drupal CMS. After integrating @edge-csrf/node-http in my project the Post request payload was in the format of Buffer instead of an array, example:

```
array:1 [
"{"type":"Buffer","data":_110,97,109,101,61,97,100,109,105,110,38,101,109,97,105,108,61,38,99,115,114,102,95,116,111,107,101,110,61,65,65" => ""
]
```

Instead of :
```
array:7 [
  "name" => "user"
  "email" => "user@gmail.com"
  "csrf_token" => "b9300a66319b9aee5668f451ffe31250404c6813078be82f8733bb201cacj9Sd"
  "subject" => "Testing forms title"
  "message" => "Testing forms desc"
  "webform_id" => "contact"
]
```

**Problem:** The @edge-csrf/node-http package was improperly converting request bodies to strings without considering their content type, leading to issues with specific formats like application/x-www-form-urlencoded.

**Solution:** A patch was implemented to check the Content-Type header and appropriately convert the Buffer to a string or JSON, ensuring correct downstream processing.